### PR TITLE
US4301 Pki-Init import option

### DIFF
--- a/Dockerfile.pki-init
+++ b/Dockerfile.pki-init
@@ -21,6 +21,7 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019 Intel Corporation'
 
 ENV PKI_INIT_DIR=/edgex/pki-init
+ENV PKI_CACHE=/etc/edgex/pki
 
 RUN set -eux; \
     apk add --no-cache ca-certificates dumb-init

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,10 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/dghubble/sling v1.2.0
 	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190228190020-eab51cabc3dc
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
-	github.com/google/pprof v0.0.0-20190515194954-54271f7e092f // indirect
 	github.com/google/uuid v1.1.1 // indirect
-	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 // indirect
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/arch v0.0.0-20190312162104-788fe5ffcd8c // indirect
-	golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5 // indirect
+	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect
 )

--- a/pkiinit/option/constant.go
+++ b/pkiinit/option/constant.go
@@ -36,3 +36,4 @@ const (
 
 var pkiInitScratchDir = filepath.Join(pkiInitBaseDir, "scratch")
 var pkiInitGeneratedDir = filepath.Join(pkiInitBaseDir, "generated")
+var pkiInitDeployDir = filepath.Join("run", "edgex", "secrets")

--- a/pkiinit/option/constant.go
+++ b/pkiinit/option/constant.go
@@ -22,6 +22,8 @@ const (
 	pkiInitExecutable  = "pki-init"
 	pkiSetupVaultJSON  = "pkisetup-vault.json"
 	envXdgRuntimeDir   = "XDG_RUNTIME_DIR"
+	envPkiCache        = "PKI_CACHE"
+	defaultPkiCacheDir = "/etc/edgex/pki"
 	pkiInitBaseDir     = "/edgex/pki-init"
 	tlsSceretFileName  = "server.key"
 	tlsCertFileName    = "server.crt"

--- a/pkiinit/option/constant.go
+++ b/pkiinit/option/constant.go
@@ -25,6 +25,7 @@ const (
 	envPkiCache        = "PKI_CACHE"
 	defaultPkiCacheDir = "/etc/edgex/pki"
 	pkiInitBaseDir     = "/edgex/pki-init"
+	tmpfsRunDir        = "/run"
 	tlsSceretFileName  = "server.key"
 	tlsCertFileName    = "server.crt"
 	caCertFileName     = "ca.pem"
@@ -36,4 +37,4 @@ const (
 
 var pkiInitScratchDir = filepath.Join(pkiInitBaseDir, "scratch")
 var pkiInitGeneratedDir = filepath.Join(pkiInitBaseDir, "generated")
-var pkiInitDeployDir = filepath.Join("run", "edgex", "secrets")
+var pkiInitDeployDir = filepath.Join(tmpfsRunDir, "edgex", "secrets")

--- a/pkiinit/option/generate.go
+++ b/pkiinit/option/generate.go
@@ -17,7 +17,6 @@ package option
 
 import (
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -129,13 +128,6 @@ func rearrangePkiByServices(baseWorkingDir, pkiSetupVaultJSONPath string) (exitC
 	return normal, nil
 }
 
-func createDirectoryIfNotExists(dirName string) (err error) {
-	if _, err := os.Stat(dirName); os.IsNotExist(err) {
-		err = os.MkdirAll(dirName, os.ModePerm)
-	}
-	return err
-}
-
 func copyGeneratedForService(servicePath, pkiOutputDir string, config cert.X509Config) error {
 	if err := createDirectoryIfNotExists(servicePath); err != nil {
 		return err
@@ -168,33 +160,4 @@ func cleanup(baseWorkingDir, scratchPath string) {
 	os.Chdir(baseWorkingDir)
 	os.RemoveAll(scratchPath)
 	log.Println("pki-init generation completes")
-}
-
-func copyFile(fileSrc, fileDest string) (int64, error) {
-	var zeroByte int64
-	sourceFileSt, err := os.Stat(fileSrc)
-	if err != nil {
-		return zeroByte, err
-	}
-
-	// only regular file allows to be copied
-	if !sourceFileSt.Mode().IsRegular() {
-		return zeroByte, fmt.Errorf("[%s] is not a regular file to be copied", fileSrc)
-	}
-
-	// now open the source file
-	source, openErr := os.Open(fileSrc)
-	if openErr != nil {
-		return zeroByte, openErr
-	}
-	defer source.Close()
-
-	// now create a new file
-	dest, createErr := os.Create(fileDest)
-	if createErr != nil {
-		return zeroByte, createErr
-	}
-	defer dest.Close()
-
-	return io.Copy(dest, source)
 }

--- a/pkiinit/option/generate.go
+++ b/pkiinit/option/generate.go
@@ -30,7 +30,7 @@ import (
 func Generate() func(*PkiInitOption) (exitCode, error) {
 	return func(pkiInitOpton *PkiInitOption) (exitCode, error) {
 
-		if isNoOp(pkiInitOpton) {
+		if isGenerateNoOp(pkiInitOpton) {
 			return normal, nil
 		}
 
@@ -38,9 +38,9 @@ func Generate() func(*PkiInitOption) (exitCode, error) {
 	}
 }
 
-func isNoOp(pkiInitOpton *PkiInitOption) bool {
+func isGenerateNoOp(pkiInitOption *PkiInitOption) bool {
 	// nop: if the flag is missing or not on
-	return pkiInitOpton == nil || !pkiInitOpton.generateOpt
+	return pkiInitOption == nil || !pkiInitOption.GenerateOpt
 }
 
 func generatePkis() (exitCode, error) {

--- a/pkiinit/option/generate_test.go
+++ b/pkiinit/option/generate_test.go
@@ -32,10 +32,13 @@ var vaultJSONPkiSetupExist bool
 func TestGenerate(t *testing.T) {
 	pkisetupLocal = true
 	vaultJSONPkiSetupExist = true
-	tearDown := setupTest(t)
+	tearDown := setupGenerateTest(t)
 	defer tearDown(t)
 
-	generateOn := NewPkiInitOption(true)
+	options := PkiInitOption{
+		GenerateOpt: true,
+	}
+	generateOn, _, _ := NewPkiInitOption(options)
 	generateOn.(*PkiInitOption).executor = testExecutor
 
 	f := Generate()
@@ -49,9 +52,13 @@ func TestGenerate(t *testing.T) {
 func TestGenerateWithPkiSetupMissing(t *testing.T) {
 	pkisetupLocal = false // this will lead to pkisetup binary missing
 	vaultJSONPkiSetupExist = true
-	tearDown := setupTest(t)
+	tearDown := setupGenerateTest(t)
 	defer tearDown(t)
-	generateOn := NewPkiInitOption(true)
+
+	options := PkiInitOption{
+		GenerateOpt: true,
+	}
+	generateOn, _, _ := NewPkiInitOption(options)
 	generateOn.(*PkiInitOption).executor = testExecutor
 
 	f := Generate()
@@ -65,10 +72,13 @@ func TestGenerateWithPkiSetupMissing(t *testing.T) {
 func TestGenerateWithVaultJSONPkiSetupMissing(t *testing.T) {
 	pkisetupLocal = true
 	vaultJSONPkiSetupExist = false // this will lead to missing json
-	tearDown := setupTest(t)
+	tearDown := setupGenerateTest(t)
 	defer tearDown(t)
 
-	generateOn := NewPkiInitOption(true)
+	options := PkiInitOption{
+		GenerateOpt: true,
+	}
+	generateOn, _, _ := NewPkiInitOption(options)
 	generateOn.(*PkiInitOption).executor = testExecutor
 
 	f := Generate()
@@ -82,10 +92,13 @@ func TestGenerateWithVaultJSONPkiSetupMissing(t *testing.T) {
 func TestGenerateOff(t *testing.T) {
 	pkisetupLocal = true
 	vaultJSONPkiSetupExist = true
-	tearDown := setupTest(t)
+	tearDown := setupGenerateTest(t)
 	defer tearDown(t)
 
-	generateOff := NewPkiInitOption(false)
+	options := PkiInitOption{
+		GenerateOpt: false,
+	}
+	generateOff, _, _ := NewPkiInitOption(options)
 	generateOff.(*PkiInitOption).executor = testExecutor
 	exitCode, err := generateOff.executeOptions(Generate())
 
@@ -94,7 +107,7 @@ func TestGenerateOff(t *testing.T) {
 	assert.Nil(err)
 }
 
-func setupTest(t *testing.T) func(t *testing.T) {
+func setupGenerateTest(t *testing.T) func(t *testing.T) {
 	testExecutor = &mockOptionsExecutor{}
 	curDir, err := os.Getwd()
 	if err != nil {

--- a/pkiinit/option/import.go
+++ b/pkiinit/option/import.go
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package option
+
+// Import option....
+func Import() func(*PkiInitOption) (exitCode, error) {
+	return func(pkiInitOpton *PkiInitOption) (exitCode, error) {
+
+		if isImportNoOp(pkiInitOpton) {
+			return normal, nil
+		}
+
+		return importPkis()
+	}
+}
+
+func isImportNoOp(pkiInitOption *PkiInitOption) bool {
+	// nop: if the flag is missing or not on
+	return pkiInitOption == nil || !pkiInitOption.ImportOpt
+}
+
+func importPkis() (exitCode, error) {
+	return normal, nil
+}

--- a/pkiinit/option/import_test.go
+++ b/pkiinit/option/import_test.go
@@ -52,7 +52,7 @@ func TestImportPriorFileChange(t *testing.T) {
 	writeTestFileToCacheDir(t)
 
 	// to allow time to finish deploy in another go-routine
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	deployEmpty, emptyErr := isDirEmpty(pkiInitDeployDir)
 
@@ -190,7 +190,7 @@ func setupImportTest(t *testing.T) func(t *testing.T) {
 func writeTestFileToCacheDir(t *testing.T) {
 	pkiCacheDir := os.Getenv(envPkiCache)
 	// make a test dir
-	testFileDir := filepath.Join(pkiCacheDir, "test")
+	testFileDir := filepath.Join(pkiCacheDir, "test", caServiceName)
 	_ = createDirectoryIfNotExists(testFileDir)
 	testFile := filepath.Join(testFileDir, "testFile")
 	testData := []byte("test data\n")

--- a/pkiinit/option/import_test.go
+++ b/pkiinit/option/import_test.go
@@ -1,0 +1,119 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package option
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImport(t *testing.T) {
+	tearDown := setupImportTest(t)
+	defer tearDown(t)
+
+	options := PkiInitOption{
+		ImportOpt: true,
+	}
+	importOn, _, _ := NewPkiInitOption(options)
+	importOn.(*PkiInitOption).executor = testExecutor
+
+	f := Import()
+	exitCode, err := f(importOn.(*PkiInitOption))
+
+	assert := assert.New(t)
+	assert.Equal(normal, exitCode)
+	assert.Nil(err)
+}
+
+// func TestGenerateWithPkiSetupMissing(t *testing.T) {
+// 	pkisetupLocal = false // this will lead to pkisetup binary missing
+// 	vaultJSONPkiSetupExist = true
+// 	tearDown := setupImportTest(t)
+// 	defer tearDown(t)
+
+// 	options := PkiInitOption{
+// 		GenerateOpt: true,
+// 	}
+// 	generateOn, _, _ := NewPkiInitOption(options)
+// 	generateOn.(*PkiInitOption).executor = testExecutor
+
+// 	f := Generate()
+// 	exitCode, err := f(generateOn.(*PkiInitOption))
+
+// 	assert := assert.New(t)
+// 	assert.Equal(exitWithError, exitCode)
+// 	assert.NotNil(err)
+// }
+
+// func TestGenerateWithVaultJSONPkiSetupMissing(t *testing.T) {
+// 	pkisetupLocal = true
+// 	vaultJSONPkiSetupExist = false // this will lead to missing json
+// 	tearDown := setupImportTest(t)
+// 	defer tearDown(t)
+
+// 	options := PkiInitOption{
+// 		GenerateOpt: true,
+// 	}
+// 	generateOn, _, _ := NewPkiInitOption(options)
+// 	generateOn.(*PkiInitOption).executor = testExecutor
+
+// 	f := Generate()
+// 	exitCode, err := f(generateOn.(*PkiInitOption))
+
+// 	assert := assert.New(t)
+// 	assert.Equal(exitWithError, exitCode)
+// 	assert.NotNil(err)
+// }
+
+// func TestGenerateOff(t *testing.T) {
+// 	pkisetupLocal = true
+// 	vaultJSONPkiSetupExist = true
+// 	tearDown := setupImportTest(t)
+// 	defer tearDown(t)
+
+// 	options := PkiInitOption{
+// 		GenerateOpt: false,
+// 	}
+// 	generateOff, _, _ := NewPkiInitOption(options)
+// 	generateOff.(*PkiInitOption).executor = testExecutor
+// 	exitCode, err := generateOff.executeOptions(Generate())
+
+// 	assert := assert.New(t)
+// 	assert.Equal(normal, exitCode)
+// 	assert.Nil(err)
+// }
+
+func setupImportTest(t *testing.T) func(t *testing.T) {
+	testExecutor = &mockOptionsExecutor{}
+	curDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("cannot get the working dir %s: %v", curDir, err)
+	}
+
+	origEnvXdgRuntimeDir := os.Getenv(envXdgRuntimeDir)
+	fmt.Println("Env XDG_RUNTIME_DIR: ", origEnvXdgRuntimeDir)
+
+	// change it to the current working directory
+	os.Setenv(envXdgRuntimeDir, curDir)
+
+	return func(t *testing.T) {
+		// cleanup
+		os.Setenv(envXdgRuntimeDir, origEnvXdgRuntimeDir)
+	}
+}

--- a/pkiinit/option/optionHelpers.go
+++ b/pkiinit/option/optionHelpers.go
@@ -1,0 +1,121 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package option
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+func copyFile(fileSrc, fileDest string) (int64, error) {
+	var zeroByte int64
+	sourceFileSt, err := os.Stat(fileSrc)
+	if err != nil {
+		return zeroByte, err
+	}
+
+	// only regular file allows to be copied
+	if !sourceFileSt.Mode().IsRegular() {
+		return zeroByte, fmt.Errorf("[%s] is not a regular file to be copied", fileSrc)
+	}
+
+	// now open the source file
+	source, openErr := os.Open(fileSrc)
+	if openErr != nil {
+		return zeroByte, openErr
+	}
+	defer source.Close()
+
+	// now create a new file
+	dest, createErr := os.Create(fileDest)
+	if createErr != nil {
+		return zeroByte, createErr
+	}
+	defer dest.Close()
+
+	return io.Copy(dest, source)
+}
+
+func createDirectoryIfNotExists(dirName string) (err error) {
+	if _, err := os.Stat(dirName); os.IsNotExist(err) {
+		err = os.MkdirAll(dirName, os.ModePerm)
+	}
+	return err
+}
+
+func isDirEmpty(dir string) (empty bool, err error) {
+	handle, err := os.Open(dir)
+	if err != nil {
+		return empty, err
+	}
+	defer handle.Close()
+
+	_, err = handle.Readdir(1)
+	if err == io.EOF {
+		// EOF error means the dir is empty
+		empty = true
+		err = nil
+	}
+
+	return empty, err
+}
+
+func copyDir(srcDir, destDir string) error {
+	srcFileInfo, statErr := os.Stat(srcDir)
+	if statErr != nil {
+		return statErr
+	}
+	if makeDirErr := os.MkdirAll(destDir, srcFileInfo.Mode()); makeDirErr != nil {
+		return makeDirErr
+	}
+
+	fileDescs, readErr := ioutil.ReadDir(srcDir)
+	if readErr != nil {
+		return readErr
+	}
+
+	for _, fileDesc := range fileDescs {
+		srcFilePath := filepath.Join(srcDir, fileDesc.Name())
+		destFilePath := filepath.Join(destDir, fileDesc.Name())
+
+		if fileDesc.IsDir() {
+			log.Printf("filepath is a dir: %s", fileDesc.Name())
+			if err := copyDir(srcFilePath, destFilePath); err != nil {
+				return err
+			}
+		} else {
+			log.Printf("coping srcFilePath: %s to destFilePath: %s", srcFilePath, destFilePath)
+			if _, copyErr := copyFile(srcFilePath, destFilePath); copyErr != nil {
+				return copyErr
+			}
+
+		}
+	}
+
+	return nil
+}
+
+func getPkiCacheDirEnv() string {
+	pkiCacheDir := os.Getenv(envPkiCache)
+	if pkiCacheDir == "" {
+		return defaultPkiCacheDir
+	}
+	return pkiCacheDir
+}

--- a/pkiinit/option/optionHelpers.go
+++ b/pkiinit/option/optionHelpers.go
@@ -96,12 +96,11 @@ func copyDir(srcDir, destDir string) error {
 		destFilePath := filepath.Join(destDir, fileDesc.Name())
 
 		if fileDesc.IsDir() {
-			log.Printf("filepath is a dir: %s", fileDesc.Name())
 			if err := copyDir(srcFilePath, destFilePath); err != nil {
 				return err
 			}
 		} else {
-			log.Printf("coping srcFilePath: %s to destFilePath: %s", srcFilePath, destFilePath)
+			log.Printf("copying srcFilePath: %s to destFilePath: %s", srcFilePath, destFilePath)
 			if _, copyErr := copyFile(srcFilePath, destFilePath); copyErr != nil {
 				return copyErr
 			}

--- a/pkiinit/option/pkiOption.go
+++ b/pkiinit/option/pkiOption.go
@@ -15,6 +15,8 @@
 //
 package option
 
+import "errors"
+
 // OptionsExecutor is an executor to process the input options
 type OptionsExecutor interface {
 	ProcessOptions() (int, error)
@@ -23,23 +25,27 @@ type OptionsExecutor interface {
 
 // PkiInitOption contains command line options for pki-init
 type PkiInitOption struct {
-	generateOpt bool
+	GenerateOpt bool
+	ImportOpt   bool
 	executor    OptionsExecutor
 }
 
 // NewPkiInitOption constructor to get options built for pki-init
-func NewPkiInitOption(generateInput bool) OptionsExecutor {
-	instance := &PkiInitOption{
-		generateOpt: generateInput,
+func NewPkiInitOption(opts PkiInitOption) (ex OptionsExecutor, statusCode int, err error) {
+	// import option cannot be attempted with other modes
+	if opts.ImportOpt && opts.GenerateOpt {
+		return ex, exitWithError.intValue(), errors.New("Cannot attempt import option with other modes")
 	}
-	instance.executor = instance
-	return instance
+	opts.executor = &opts
+
+	return &opts, normal.intValue(), nil
 }
 
 // ProcessOptions processes all the input options from the caller
 func (pkiInitOpt *PkiInitOption) ProcessOptions() (int, error) {
 	statusCode, err := pkiInitOpt.executor.executeOptions(
 		Generate(),
+		Import(),
 	)
 
 	return statusCode.intValue(), err

--- a/pkiinit/pkiInit.go
+++ b/pkiinit/pkiInit.go
@@ -40,12 +40,14 @@ var exitInstance = newExit()
 var dispatcherInstance = newOptionDispatcher()
 var helpOpt bool
 var generateOpt bool
+var importOpt bool
 
 func init() {
 	// define and register command line flags:
 	flag.BoolVar(&helpOpt, "h", false, "help message")
 	flag.BoolVar(&helpOpt, "help", false, "help message")
 	flag.BoolVar(&generateOpt, "generate", false, "to generate a new PKI from scratch")
+	flag.BoolVar(&importOpt, "import", false, " deploys a PKI from a cached PKI")
 }
 
 func main() {
@@ -86,7 +88,21 @@ func (code *exitCode) callExit(statusCode int) {
 	os.Exit(statusCode)
 }
 
+func setupPkiInitOption() (executor option.OptionsExecutor, status int, err error) {
+	opts := option.PkiInitOption{
+		GenerateOpt: generateOpt,
+		ImportOpt:   importOpt,
+	}
+
+	return option.NewPkiInitOption(opts)
+}
+
 func (dispatcher *pkiInitOptionDispatcher) run() (statusCode int, err error) {
-	pkiInitOption := option.NewPkiInitOption(generateOpt)
-	return pkiInitOption.ProcessOptions()
+
+	optsExecutor, statusCode, err := setupPkiInitOption()
+	if err != nil {
+		return
+	}
+
+	return optsExecutor.ProcessOptions()
 }

--- a/pkiinit/pkiInit_test.go
+++ b/pkiinit/pkiInit_test.go
@@ -74,6 +74,19 @@ func TestGenerateOptionWithRunError(t *testing.T) {
 	assert.Equal(true, generateOpt)
 }
 
+func TestSetupPkiInitOption(t *testing.T) {
+	tearDown := setupTest(t)
+	origArgs := os.Args
+	defer tearDown(t, origArgs)
+	assert := assert.New(t)
+
+	generateOpt = true
+
+	_, status, err := setupPkiInitOption()
+	assert.Equal(0, status)
+	assert.Nil(err)
+}
+
 func setupTest(t *testing.T) func(t *testing.T, args []string) {
 	exitInstance = newTestExit()
 	dispatcherInstance = newTestDispatcher()

--- a/pkiinit/pkiInit_test.go
+++ b/pkiinit/pkiInit_test.go
@@ -74,6 +74,18 @@ func TestGenerateOptionWithRunError(t *testing.T) {
 	assert.Equal(true, generateOpt)
 }
 
+func TestImportOptionOk(t *testing.T) {
+	tearDown := setupTest(t)
+	origArgs := os.Args
+	defer tearDown(t, origArgs)
+	assert := assert.New(t)
+
+	runWithImportOption(false)
+	assert.Equal(0, (exitInstance.(*testExitCode)).getStatusCode())
+	assert.Equal(false, helpOpt)
+	assert.Equal(true, importOpt)
+}
+
 func TestSetupPkiInitOption(t *testing.T) {
 	tearDown := setupTest(t)
 	origArgs := os.Args
@@ -94,6 +106,7 @@ func setupTest(t *testing.T) func(t *testing.T, args []string) {
 		// reset after each test
 		helpOpt = false
 		generateOpt = false
+		importOpt = false
 		hasDispatchError = false
 		os.Args = args
 	}
@@ -116,6 +129,14 @@ func runWithHelpOption() {
 func runWithGenerateOption(hasError bool) {
 	// case 3: generate option given
 	os.Args = []string{"cmd", "-generate"}
+	printCommandLineStrings(os.Args)
+	hasDispatchError = hasError
+	main()
+}
+
+func runWithImportOption(hasError bool) {
+	// case 3: generate option given
+	os.Args = []string{"cmd", "-import"}
 	printCommandLineStrings(os.Args)
 	hasDispatchError = hasError
 	main()
@@ -155,7 +176,7 @@ func newTestDispatcher() optionDispatcher {
 }
 
 func (testDispatcher *testPkiInitOptionDispatcher) run() (statusCode int, err error) {
-	fmt.Printf("In test flag value: helpOpt = %v, generateOpt = %v\n", helpOpt, generateOpt)
+	fmt.Printf("In test flag value: helpOpt = %v, generateOpt = %v, importOpt = %v\n", helpOpt, generateOpt, importOpt)
 	if hasDispatchError {
 		statusCode = 2
 		err = errors.New("dispatch error found")


### PR DESCRIPTION
Import option reads the PKI stuffs from cache area (specified by env PKI_ENV) in docker container edgex-pki-init and deploys to destination directory that is a binding mount docker path ```/run/edgex/secrets/```.